### PR TITLE
Added another check to avoid errors on loading scenes

### DIFF
--- a/addons/screen_effects/scripts/effects_handler.gd
+++ b/addons/screen_effects/scripts/effects_handler.gd
@@ -42,7 +42,7 @@ var mvCameraAngularVelocity: Vector3 = Vector3(0.0, 0.0, 0.0);
 
 func _ready() -> void:
 	mCamera = get_viewport().get_camera_3d();
-	if (is_instance_valid(mCamera)==false):
+	if (is_instance_valid(mCamera)==false || mCamera.is_inside_tree() == false):
 		printerr("[EffectsHandler] No active camera found.");
 		return;
 	
@@ -76,7 +76,7 @@ func _ready() -> void:
 #-------------------------------------------------------
 
 func _process(afDeltaTime : float)->void:	
-	if (is_instance_valid(mCamera) == false): return;
+	if (is_instance_valid(mCamera) == false || mCamera.is_inside_tree() == false): return;
 
 	####################################################################################################
 	# Fov Fade
@@ -276,7 +276,7 @@ func _process(afDeltaTime : float)->void:
 #-------------------------------------------------------
 
 func _physics_process(afTimeStep: float) -> void:
-	if (is_instance_valid(mCamera)==false): return;
+	if (is_instance_valid(mCamera)==false || mCamera.is_inside_tree() == false): return;
 	if (mbMotionBlurActive==false): return;
 	
 	#########################


### PR DESCRIPTION
In my project (4.4dev4), when I loaded a scene (which doesn't have the camera already registered as mCamera), I got a bunch of errors ![camera-scene-tree](https://github.com/user-attachments/assets/463c556a-e18c-4ac5-9d08-bd3669645c9f)

This check for whether the camera is in the tree fixed them for me.

I haven't tested whether making a null camera intentionally makes this new check to fail, but in classic programming fashion, the second OR condition should be checked only if the first condition is false.