### PR TITLE
Disable motion blur by default

### DIFF
--- a/addons/screen_effects/scripts/effects_handler.gd
+++ b/addons/screen_effects/scripts/effects_handler.gd
@@ -23,7 +23,7 @@ var mvScreenBlurInst: Array[cScreenBlur];
 var mlScreenBlurID: int = -1;
 var mvScreenFadeInst: Array[cScreenFade];
 var mlScreenFadeID: int = -1;
-var mbMotionBlurActive: bool = true;
+var mbMotionBlurActive: bool = false;
 var mfLinearMotionBlurAmount: float = 0.05;
 var mfAngularMotionBlurAmount: float = 0.1;
 var mfMotionBlurFadeSpeed: float = 24.0;


### PR DESCRIPTION
Closes #3

Most players turn off motion blur in their games. Having it a default choice without warning the developer about adding this feature to their games is unwise. For example, this avoids some playtester saying "I wish I could turn off motion blur" and the developer replies with "huh? there is no motion blur." and the ensuing chaos~